### PR TITLE
Add automation for publishing to BCR

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/rabbitmq/looking_glass",
+  "maintainers": [
+    {
+      "email": "kuryloskip@vmware.com",
+      "github": "pjk25",
+      "name": "Rin Kuryloski"
+    }
+  ],
+  "repository": [
+    "github:rabbitmq/looking_glass"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,27 @@
+shell_commands: &shell_commands
+- curl -O https://raw.githubusercontent.com/kerl/kerl/master/kerl
+- chmod a+x kerl
+- ./kerl update releases
+- ./kerl build ${ERLANG_VERSION}
+- ./kerl install ${ERLANG_VERSION} ~/kerl/${ERLANG_VERSION}
+- realpath ~/kerl/${ERLANG_VERSION}
+
+platforms:
+  macos:
+    environment:
+      ERLANG_VERSION: "25.0"
+      ERLANG_HOME: /Users/buildkite/kerl/25.0
+    shell_commands: *shell_commands
+    build_flags:
+    - --incompatible_strict_action_env
+    build_targets:
+    - '@com_github_rabbitmq_looking_glass//:erlang_app'
+  ubuntu2004:
+    environment:
+      ERLANG_VERSION: "25.0"
+      ERLANG_HOME: /var/lib/buildkite-agent/kerl/25.0
+    shell_commands: *shell_commands
+    build_flags:
+    - --incompatible_strict_action_env
+    build_targets:
+    - '@com_github_rabbitmq_looking_glass//:erlang_app'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/looking_glass-{VERSION}.tar.gz"
+}


### PR DESCRIPTION
When a release is created, the "Publish to BCR" github application will create a PR to add that release to the Bazel Central Repository

The release process is as follows:
1. tag the commit intended for release
2. push the tag
3. Download the .tar.gz source archive for that tag
4. Create a release for that tag, and attach the download as an artifact

See
https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwiv2JD-qpL_AhXgR_EDHXFoBBgQFnoECCoQAQ&url=https%3A%2F%2Fblog.bazel.build%2F2023%2F02%2F15%2Fgithub-archive-checksum.html&usg=AOvVaw2AUk8h6Gf73CM8ZurKBkSq for an explanation of why the source archive is manually attached