### PR TITLE
Update lz4 default branch in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-    {lz4, {git, "https://github.com/rabbitmq/lz4-erlang", {branch, "master"}}}
+    {lz4, {git, "https://github.com/rabbitmq/lz4-erlang", {branch, "main"}}}
 ]}.
 
 {pre_hooks, [


### PR DESCRIPTION
LookingGlass fails to install using rebar3 because the "master" branch does not exist anymore. Fails with:

```shell
error: pathspec 'origin/master' did not match any file(s) known to git
```